### PR TITLE
Fix pod name for pod try example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pod 'AmplienceDelivery', '~> 1.0.0'
 
 Or, quickly try out our examples:
 ```bash
-pod try Amplience
+pod try AmplienceDelivery
 ```
 
 ## Swift Package Manager


### PR DESCRIPTION
Fix pod name to `AmplienceDelivery` for pod try example.